### PR TITLE
[Android Client] Update gRPC to 1.0

### DIFF
--- a/client/java-android/.idea/.name
+++ b/client/java-android/.idea/.name
@@ -1,1 +1,0 @@
-My Application

--- a/client/java-android/.idea/copyright/Apache.xml
+++ b/client/java-android/.idea/copyright/Apache.xml
@@ -1,6 +1,0 @@
-<component name="CopyrightManager">
-  <copyright>
-    <option name="myName" value="Apache" />
-    <option name="notice" value="   Copyright &amp;#36;today.year Google Inc.&#10;&#10;   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;   you may not use this file except in compliance with the License.&#10;   You may obtain a copy of the License at&#10;&#10;       http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;   Unless required by applicable law or agreed to in writing, software&#10;   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;   See the License for the specific language governing permissions and&#10;   limitations under the License." />
-  </copyright>
-</component>

--- a/client/java-android/.idea/copyright/profiles_settings.xml
+++ b/client/java-android/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,3 @@
 <component name="CopyrightManager">
-  <settings default="Apache" />
+  <settings default="" />
 </component>

--- a/client/java-android/.idea/gradle.xml
+++ b/client/java-android/.idea/gradle.xml
@@ -5,20 +5,14 @@
       <GradleProjectSettings>
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.10" />
-        <option name="gradleJvm" value="1.7" />
+        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="myModules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-          </set>
-        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/client/java-android/.idea/misc.xml
+++ b/client/java-android/.idea/misc.xml
@@ -3,24 +3,6 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="JavadocGenerationManager">
-    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/app/build/docs" />
-    <option name="OPTION_SCOPE" value="protected" />
-    <option name="OPTION_HIERARCHY" value="true" />
-    <option name="OPTION_NAVIGATOR" value="true" />
-    <option name="OPTION_INDEX" value="true" />
-    <option name="OPTION_SEPARATE_INDEX" value="true" />
-    <option name="OPTION_DOCUMENT_TAG_USE" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_AUTHOR" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_VERSION" value="false" />
-    <option name="OPTION_DOCUMENT_TAG_DEPRECATED" value="true" />
-    <option name="OPTION_DEPRECATED_LIST" value="true" />
-    <option name="OTHER_OPTIONS" />
-    <option name="HEAP_SIZE" />
-    <option name="LOCALE" />
-    <option name="OPEN_IN_BROWSER" value="true" />
-    <option name="OPTION_INCLUDE_LIBS" value="false" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -55,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/client/java-android/.idea/modules.xml
+++ b/client/java-android/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/android-client.iml" filepath="$PROJECT_DIR$/android-client.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/java-android.iml" filepath="$PROJECT_DIR$/java-android.iml" />
     </modules>
   </component>
 </project>

--- a/client/java-android/.idea/vcs.xml
+++ b/client/java-android/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/client/java-android/app/build.gradle
+++ b/client/java-android/app/build.gradle
@@ -41,32 +41,23 @@ protobuf {
         // The version of protoc must match protobuf-java. If you don't depend on
         // protobuf-java directly, you will be transitively depending on the
         // protobuf-java version that grpc depends on.
-        artifact = "com.google.protobuf:protoc:3.0.0-beta-2"
+        artifact = "com.google.protobuf:protoc:3.0.0"
     }
     plugins {
+        javalite {
+            artifact = "com.google.protobuf:protoc-gen-javalite:3.0.0"
+        }
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.2'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.0.0' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
         all().each { task ->
-            task.builtins {
-                javanano {
-                    // Options added to --javanano_out
-                    // Javanano option to skip services.
-                    // Nano doesn't support services.
-                    // See: https://github.com/google/protobuf/tree/master/javanano#nano-generator-options
-                    option 'ignore_services=true'
-                }
-            }
-
             task.plugins {
+                javalite {}
                 grpc {
                     // Options added to --grpc_out
-                    // JavaNano is a special code generator and runtime library designed
-                    // specially for resource-restricted systems, like Android.
-                    // See: https://github.com/google/protobuf/tree/master/javanano
-                    option 'nano=true'
+                    option 'lite'
                 }
             }
         }
@@ -79,7 +70,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'com.android.support:design:23.2.1'
     compile 'javax.annotation:javax.annotation-api:1.2'
-    compile 'io.grpc:grpc-okhttp:0.13.2'
-    compile 'io.grpc:grpc-protobuf-nano:0.13.2'
-    compile 'io.grpc:grpc-stub:0.13.2'
+    compile 'io.grpc:grpc-okhttp:1.0.0'
+    compile 'io.grpc:grpc-protobuf-lite:1.0.0'
+    compile 'io.grpc:grpc-stub:1.0.0'
 }

--- a/client/java-android/app/src/main/java/io/grpc/examples/simonandroid/MainActivity.java
+++ b/client/java-android/app/src/main/java/io/grpc/examples/simonandroid/MainActivity.java
@@ -34,10 +34,10 @@ import java.util.Random;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.examples.simonsays.nano.SimonSaysGrpc;
-import io.grpc.examples.simonsays.nano.Request;
-import io.grpc.examples.simonsays.nano.Response;
-import io.grpc.examples.simonsays.nano.SimonSays;
+import io.grpc.examples.simonsays.Color;
+import io.grpc.examples.simonsays.Request;
+import io.grpc.examples.simonsays.Response;
+import io.grpc.examples.simonsays.SimonSaysGrpc;
 import io.grpc.stub.StreamObserver;
 
 public class MainActivity extends AppCompatActivity {
@@ -92,9 +92,9 @@ public class MainActivity extends AppCompatActivity {
     */
     private void joinGame(StreamObserver<Request> requests) {
         Log.i(LOG_TAG, "Joining a game");
-        Request.Player player = new Request.Player();
-        player.id = playerId;
-        Request request = new Request().setJoin(player);
+
+        Request.Player player = Request.Player.newBuilder().setId(playerId).build();
+        Request request = Request.newBuilder().setJoin(player).build();
         sendRequest(request);
     }
 
@@ -134,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
     */
     public void onBlue(View view) {
         Log.i(LOG_TAG, "Pressed Blue!");
-        sendPress(SimonSays.BLUE);
+        sendPress(Color.BLUE);
     }
 
     /*
@@ -142,7 +142,7 @@ public class MainActivity extends AppCompatActivity {
     */
     public void onRed(View view) {
         Log.i(LOG_TAG, "Pressed Red");
-        sendPress(SimonSays.RED);
+        sendPress(Color.RED);
     }
 
     /*
@@ -150,7 +150,7 @@ public class MainActivity extends AppCompatActivity {
     */
     public void onGreen(View view) {
         Log.i(LOG_TAG, "Pressed Green!");
-        sendPress(SimonSays.GREEN);
+        sendPress(Color.GREEN);
     }
 
     /*
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity {
     */
     public void onYellow(View view) {
         Log.i(LOG_TAG, "Pressed Yellow!");
-        sendPress(SimonSays.YELLOW);
+        sendPress(Color.YELLOW);
     }
 
     /*
@@ -193,9 +193,8 @@ public class MainActivity extends AppCompatActivity {
     /*
     * Send a button press
     */
-    private void sendPress(int color) {
-        Request request = new Request();
-        request.setPress(color);
+    private void sendPress(Color color) {
+        Request request = Request.newBuilder().setPress(color).build();
         sendRequest(request);
     }
 
@@ -210,12 +209,12 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void run() {
                 switch (finalValue.getEventCase()) {
-                    case Response.TURN_FIELD_NUMBER: {
+                    case TURN: {
                         handleTurn(finalValue.getTurn());
                         break;
                     }
 
-                    case Response.LIGHTUP_FIELD_NUMBER: {
+                    case LIGHTUP: {
                         handleLightup(finalValue.getLightup());
                         break;
                     }
@@ -227,30 +226,30 @@ public class MainActivity extends AppCompatActivity {
     /*
     * Handle lightup events
     */
-    private void handleLightup(int lightup) {
+    private void handleLightup(Color lightup) {
         switch (lightup) {
-            case SimonSays.RED: {
+            case RED: {
                 Log.i(LOG_TAG, "Lightup: RED");
                 Button button = (Button) findViewById(R.id.button_red);
                 button.startAnimation(buttonAnimation);
                 break;
             }
 
-            case SimonSays.YELLOW: {
+            case YELLOW: {
                 Log.i(LOG_TAG, "Lightup: YELLOW");
                 Button button = (Button) findViewById(R.id.button_yellow);
                 button.startAnimation(buttonAnimation);
                 break;
             }
 
-            case SimonSays.GREEN: {
+            case GREEN: {
                 Log.i(LOG_TAG, "Lightup: GREEN");
                 Button button = (Button) findViewById(R.id.button_green);
                 button.startAnimation(buttonAnimation);
                 break;
             }
 
-            case SimonSays.BLUE: {
+            case BLUE: {
                 Log.i(LOG_TAG, "Lightup: BLUE");
                 Button button = (Button) findViewById(R.id.button_blue);
                 button.startAnimation(buttonAnimation);
@@ -262,27 +261,27 @@ public class MainActivity extends AppCompatActivity {
     /*
     * Handle turn events
     */
-    private void handleTurn(int turn) {
+    private void handleTurn(Response.State turn) {
         switch (turn) {
-            case Response.BEGIN: {
+            case BEGIN: {
                 Log.i(LOG_TAG, "It's my turn!");
                 Toast.makeText(getApplicationContext(), "Welcome to Simon Says", Toast.LENGTH_SHORT).show();
                 break;
             }
 
-            case Response.START_TURN: {
+            case START_TURN: {
                 Log.i(LOG_TAG, "Starting turn");
                 Toast.makeText(getApplicationContext(), "It's Your Turn.", Toast.LENGTH_SHORT).show();
                 break;
             }
 
-            case Response.STOP_TURN: {
+            case STOP_TURN: {
                 Log.i(LOG_TAG, "Stopping Turn");
                 Toast.makeText(getApplicationContext(), "Other Players Turn...", Toast.LENGTH_SHORT).show();
                 break;
             }
 
-            case Response.WIN: {
+            case WIN: {
                 Log.i(LOG_TAG, "WON!");
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 builder.setTitle("YOU WON :)").setPositiveButton("CLOSE", new DialogInterface.OnClickListener() {
@@ -296,7 +295,7 @@ public class MainActivity extends AppCompatActivity {
                 break;
             }
 
-            case Response.LOSE: {
+            case LOSE: {
                 Log.i(LOG_TAG, "LOST");
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 builder.setTitle("YOU LOST :(").setPositiveButton("CLOSE", new DialogInterface.OnClickListener() {

--- a/client/java-android/app/src/main/proto/simonsays.proto
+++ b/client/java-android/app/src/main/proto/simonsays.proto
@@ -20,7 +20,7 @@ package simonsays;
 
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.simonsays";
-option java_outer_classname = "SimonSays";
+option java_outer_classname = "SimonSaysService";
 
 /*
     The Simon Says service.

--- a/client/java-android/build.gradle
+++ b/client/java-android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.5'
+        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/client/java-android/gradle/wrapper/gradle-wrapper.properties
+++ b/client/java-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
This commit moves the go dependencies to gRPC 1.0,
as well as switching to using the official gRPC Docker
images for development.

On top of this, ReplicaControllers have been removed in
favour of ReplicaSets/Deployments.